### PR TITLE
Cli man page generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
           PKG_DIR="reclaim-cli-${TARGET}"
           mkdir -p "dist/${PKG_DIR}"
           cp "${BIN}" "dist/${PKG_DIR}/reclaim"
+          cargo run --locked --bin reclaim-man -- --output "dist/${PKG_DIR}/reclaim.1"
           cp README.md "dist/${PKG_DIR}/README.md"
           cp AGENTS.md "dist/${PKG_DIR}/AGENTS.md"
           tar -C dist -czf "dist/${ASSET}" "${PKG_DIR}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ea63a92086df93893164221ad4f24142086d535b3a0957b9b9bea2dc86301"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +483,7 @@ name = "reclaim"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap_mangen",
  "reqwest",
  "serde",
  "serde_json",
@@ -533,6 +544,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rustls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.59", features = ["derive", "env"] }
+clap_mangen = "0.2.31"
 reqwest = { version = "0.11.27", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ Use `--format json` when output should be machine-readable:
 cargo run -- list --format json
 ```
 
+## Man page
+
+Generate `reclaim(1)` from the clap CLI definition:
+
+```bash
+cargo run --bin reclaim-man
+```
+
+By default this writes `man/reclaim.1`. To choose a different destination:
+
+```bash
+cargo run --bin reclaim-man -- --output /tmp/reclaim.1
+```
+
+Release archives also include `reclaim.1` next to the binary.
+
 ## API notes
 
 This foundation is based on observed usage from:

--- a/man/reclaim.1
+++ b/man/reclaim.1
@@ -1,0 +1,69 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH reclaim 1  "reclaim 0.1.0" 
+.SH NAME
+reclaim \- Simple CLI for Reclaim.ai tasks.
+.SH SYNOPSIS
+\fBreclaim\fR [\fB\-\-api\-key\fR] [\fB\-\-base\-url\fR] [\fB\-\-timeout\-secs\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
+.SH DESCRIPTION
+Simple CLI for Reclaim.ai tasks.
+.PP
+Set your API key with RECLAIM_API_KEY or pass \-\-api\-key.
+Use \-\-format json when another tool/agent will parse the output.
+.SH OPTIONS
+.TP
+\fB\-\-api\-key\fR \fI<API_KEY>\fR
+Reclaim API key. Falls back to RECLAIM_API_KEY.
+.RS
+May also be specified with the \fBRECLAIM_API_KEY\fR environment variable. 
+.RE
+.TP
+\fB\-\-base\-url\fR \fI<BASE_URL>\fR [default: https://api.app.reclaim.ai/api]
+Reclaim API base URL.
+.RS
+May also be specified with the \fBRECLAIM_BASE_URL\fR environment variable. 
+.RE
+.TP
+\fB\-\-timeout\-secs\fR \fI<TIMEOUT_SECS>\fR [default: 15]
+HTTP timeout in seconds.
+.RS
+May also be specified with the \fBRECLAIM_TIMEOUT_SECS\fR environment variable. 
+.RE
+.TP
+\fB\-\-format\fR \fI<FORMAT>\fR [default: human]
+Output format.
+.br
+
+.br
+[\fIpossible values: \fRhuman, json]
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print version
+.SH SUBCOMMANDS
+.TP
+reclaim\-list(1)
+List tasks (active by default).
+.TP
+reclaim\-get(1)
+Get one task by ID.
+.TP
+reclaim\-create(1)
+Create a new task.
+.TP
+reclaim\-help(1)
+Print this message or the help of the given subcommand(s)
+.SH EXTRA
+Examples:
+  reclaim list
+  reclaim list \-\-all \-\-format json
+  reclaim get 123
+  reclaim create \-\-title "Plan Q1 roadmap" \-\-priority P2 \-\-event\-category WORK
+  RECLAIM_API_KEY=... reclaim list
+
+Agent\-friendly tip:
+  Use \-\-format json for stable machine\-readable output.
+.SH VERSION
+v0.1.0

--- a/src/bin/reclaim-man.rs
+++ b/src/bin/reclaim-man.rs
@@ -1,0 +1,41 @@
+#[allow(dead_code)]
+#[path = "../cli.rs"]
+mod cli;
+
+use clap::{CommandFactory, Parser};
+use std::{error::Error, fs, path::PathBuf};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "reclaim-man",
+    about = "Generate a reclaim(1) man page from the CLI definition."
+)]
+struct Args {
+    #[arg(
+        short,
+        long,
+        default_value = "man/reclaim.1",
+        help = "Where to write the generated man page."
+    )]
+    output: PathBuf,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+
+    if let Some(parent) = args.output.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let command = cli::Cli::command();
+    let man = clap_mangen::Man::new(command);
+    let mut buffer = Vec::new();
+    man.render(&mut buffer)?;
+
+    fs::write(&args.output, buffer)?;
+    eprintln!("Wrote {}", args.output.display());
+
+    Ok(())
+}


### PR DESCRIPTION
Add automated man page generation for the `reclaim` CLI.

---
<p><a href="https://cursor.com/agents?id=bc-ef24dd02-0a11-4fa4-bc29-98ac0691e4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef24dd02-0a11-4fa4-bc29-98ac0691e4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

