### PR TITLE
Release build issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,11 @@ jobs:
       - name: Package archive
         shell: bash
         run: |
-          BIN="target/${TARGET}/release/reclaim"
+          BIN_TARGET="${RUST_TARGET}"
+          if [ -z "${BIN_TARGET}" ]; then
+            BIN_TARGET="${TARGET}"
+          fi
+          BIN="target/${BIN_TARGET}/release/reclaim"
           PKG_DIR="reclaim-cli-${TARGET}"
           mkdir -p "dist/${PKG_DIR}"
           cp "${BIN}" "dist/${PKG_DIR}/reclaim"
@@ -112,6 +116,7 @@ jobs:
           tar -C dist -czf "dist/${ASSET}" "${PKG_DIR}"
         env:
           TARGET: ${{ matrix.target }}
+          RUST_TARGET: ${{ matrix.rust_target }}
           ASSET: ${{ matrix.asset }}
 
       - name: Upload archive


### PR DESCRIPTION
Fixes the release packaging step to correctly locate the built binary for zigbuild targets.

The "Package archive" step was attempting to copy the `reclaim` binary from `target/${TARGET}/release/reclaim`. However, for `cargo zigbuild` targets with aliases (e.g., `TARGET=x86_64-unknown-linux-gnu.2.26`, `RUST_TARGET=x86_64-unknown-linux-gnu`), the binary is actually built and placed in `target/${RUST_TARGET}/release/reclaim`. This PR updates the workflow to use `RUST_TARGET` for the binary path when defined, falling back to `TARGET` otherwise.

---
<p><a href="https://cursor.com/agents?id=bc-46ced6f3-333a-4421-bd9e-c32f26f231c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46ced6f3-333a-4421-bd9e-c32f26f231c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

