### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Foundational Rust CLI for interacting with Reclaim.ai.
   - `src/error.rs` for actionable errors with fix hints
 - Foundational commands:
   - `reclaim list`
+  - `reclaim list --filter open|completed`
   - `reclaim dashboard` (interactive TUI)
   - `reclaim get <TASK_ID>`
   - `reclaim create --title "..." [options]`
@@ -70,6 +71,8 @@ export RECLAIM_API_KEY=your_api_key_here
 
 ```bash
 cargo run -- list
+cargo run -- list --filter open
+cargo run -- list --filter completed
 cargo run -- dashboard
 cargo run -- get 123
 cargo run -- create --title "Plan sprint"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Foundational Rust CLI for interacting with Reclaim.ai.
   - `src/error.rs` for actionable errors with fix hints
 - Foundational commands:
   - `reclaim list`
-  - `reclaim list --filter open|completed`
+  - `reclaim list --filter NEW|SCHEDULED|IN_PROGRESS|COMPLETE|CANCELLED|ARCHIVED|open|completed`
   - `reclaim dashboard` (interactive TUI)
   - `reclaim get <TASK_ID>`
   - `reclaim create --title "..." [options]`
@@ -70,17 +70,18 @@ export RECLAIM_API_KEY=your_api_key_here
 2. Run commands:
 
 ```bash
-cargo run -- list
-cargo run -- list --filter open
-cargo run -- list --filter completed
-cargo run -- dashboard
-cargo run -- get 123
-cargo run -- create --title "Plan sprint"
-cargo run -- patch 123 --set priority=P4 --set snoozeUntil=2026-02-25T17:00:00Z
-cargo run -- put 123 --set priority=P2
-cargo run -- delete 123
-cargo run -- events list --start 2026-02-01 --end 2026-02-28
-cargo run -- events create --calendar-id 829105 --title "Team sync" --start 2026-02-21T18:30:00Z --end 2026-02-21T19:00:00Z
+cargo run --bin reclaim -- list
+cargo run --bin reclaim -- list --filter open
+cargo run --bin reclaim -- list --filter completed
+cargo run --bin reclaim -- list --filter IN_PROGRESS
+cargo run --bin reclaim -- dashboard
+cargo run --bin reclaim -- get 123
+cargo run --bin reclaim -- create --title "Plan sprint"
+cargo run --bin reclaim -- patch 123 --set priority=P4 --set snoozeUntil=2026-02-25T17:00:00Z
+cargo run --bin reclaim -- put 123 --set priority=P2
+cargo run --bin reclaim -- delete 123
+cargo run --bin reclaim -- events list --start 2026-02-01 --end 2026-02-28
+cargo run --bin reclaim -- events create --calendar-id 829105 --title "Team sync" --start 2026-02-21T18:30:00Z --end 2026-02-21T19:00:00Z
 ```
 
 ## Interactive dashboard
@@ -88,7 +89,7 @@ cargo run -- events create --calendar-id 829105 --title "Team sync" --start 2026
 Open a terminal dashboard for your tasks:
 
 ```bash
-cargo run -- dashboard
+cargo run --bin reclaim -- dashboard
 ```
 
 Keyboard shortcuts (Vim-friendly):
@@ -101,23 +102,23 @@ Keyboard shortcuts (Vim-friendly):
 Use `--format json` when output should be machine-readable:
 
 ```bash
-cargo run -- list --format json
+cargo run --bin reclaim -- list --format json
 ```
 
 Use `--json` and `--set key=value` on `put`/`patch` for agent-friendly updates:
 
 ```bash
 # Partial update (PATCH)
-cargo run -- patch 123 \
+cargo run --bin reclaim -- patch 123 \
   --set priority=P4 \
   --set snoozeUntil=2026-02-25T17:00:00Z \
   --format json
 
 # Full replace (PUT) using a JSON object
-cargo run -- put 123 --json '{"title":"Plan sprint","priority":"P2"}' --format json
+cargo run --bin reclaim -- put 123 --json '{"title":"Plan sprint","priority":"P2"}' --format json
 
 # Create an event
-cargo run -- events create \
+cargo run --bin reclaim -- events create \
   --calendar-id 829105 \
   --title "UCA Standup" \
   --start 2026-02-19T18:30:00Z \
@@ -126,7 +127,7 @@ cargo run -- events create \
   --format json
 
 # Update an event using field overrides
-cargo run -- events update \
+cargo run --bin reclaim -- events update \
   --calendar-id 829105 \
   --event-id r2d260ojiopn \
   --set priority=P4 \
@@ -134,7 +135,7 @@ cargo run -- events update \
   --format json
 
 # Advanced event action payload
-cargo run -- events apply \
+cargo run --bin reclaim -- events apply \
   --json '{"actionsTaken":[{"type":"CancelEventAction","policyId":"00000000-0000-0000-0000-000000000000","eventKey":"829105/r2d260ojiopn"}]}' \
   --format json
 ```

--- a/README.md
+++ b/README.md
@@ -1,168 +1,120 @@
 # reclaim-cli
 
-Foundational Rust CLI for interacting with Reclaim.ai.
-
-## What this includes
-
-- Binary executable named **`reclaim`**
-- Clear CLI/API separation in code:
-  - `src/cli.rs` for command parsing and help text
-  - `src/reclaim_api.rs` for Reclaim API abstraction + HTTP implementation
-  - `src/error.rs` for actionable errors with fix hints
-- Foundational commands:
-  - `reclaim list`
-  - `reclaim list --filter NEW|SCHEDULED|IN_PROGRESS|COMPLETE|CANCELLED|ARCHIVED|open|completed`
-  - `reclaim dashboard` (interactive TUI)
-  - `reclaim get <TASK_ID>`
-  - `reclaim create --title "..." [options]`
-  - `reclaim put <TASK_ID> --json '{...}'` or `--set key=value`
-  - `reclaim patch <TASK_ID> --json '{...}'` and/or `--set key=value`
-  - `reclaim delete <TASK_ID>`
-  - `reclaim events list`
-  - `reclaim events get <CALENDAR_ID> <EVENT_ID>`
-  - `reclaim events create|update|delete ...`
+CLI for interacting with Reclaim.ai. Manage tasks, events, and calendars from your terminal.
 
 ## Installation
 
-### Option 0: Install script
+### Install script
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cruzluna/reclaim-cli/main/install.sh | bash
 ```
 
-Useful overrides:
+Options:
 - `RECLAIM_INSTALL_TAG` (default: `latest`)
 - `RECLAIM_INSTALL_DIR` (default: `$HOME/.local/bin`)
 - `RECLAIM_INSTALL_TARGET` (for manual target selection)
 
-### Option 1: Download a release binary (recommended)
+### Download release binary
 
-1. Go to GitHub Releases and download the archive for your platform:
-   - `reclaim-cli-<target>.tar.gz`
-2. Extract it:
+1. Download the archive for your platform from [GitHub Releases](https://github.com/cruzluna/reclaim-cli/releases)
+2. Extract and install:
 
 ```bash
-tar -xzf reclaim-cli-<target>.tar.gz
+tar -xzf reclaim-cli-*.tar.gz
+install -m 0755 reclaim-cli-*/reclaim /usr/local/bin/reclaim
 ```
 
-3. Move the `reclaim` binary into your `PATH`:
+### Install from source
 
 ```bash
-install -m 0755 reclaim-cli-<target>/reclaim /usr/local/bin/reclaim
-```
-
-### Option 2: Install from source
-
-```bash
-git clone https://github.com/cruzluna/reclaim-cli.git
-cd reclaim-cli
 cargo install --path .
 ```
 
-## Quick start
-
-1. Set API key:
+## Setup
 
 ```bash
 export RECLAIM_API_KEY=your_api_key_here
 ```
 
-2. Run commands:
+## Quick start
 
 ```bash
-cargo run --bin reclaim -- list
-cargo run --bin reclaim -- list --filter open
-cargo run --bin reclaim -- list --filter completed
-cargo run --bin reclaim -- list --filter IN_PROGRESS
-cargo run --bin reclaim -- dashboard
-cargo run --bin reclaim -- get 123
-cargo run --bin reclaim -- create --title "Plan sprint"
-cargo run --bin reclaim -- patch 123 --set priority=P4 --set snoozeUntil=2026-02-25T17:00:00Z
-cargo run --bin reclaim -- put 123 --set priority=P2
-cargo run --bin reclaim -- delete 123
-cargo run --bin reclaim -- events list --start 2026-02-01 --end 2026-02-28
-cargo run --bin reclaim -- events create --calendar-id 829105 --title "Team sync" --start 2026-02-21T18:30:00Z --end 2026-02-21T19:00:00Z
+reclaim list
+reclaim list --filter open
+reclaim list --filter completed
+reclaim dashboard
+reclaim get 123
+reclaim create --title "Plan sprint"
+reclaim patch 123 --set priority=P4
+reclaim put 123 --set priority=P2
+reclaim delete 123
+
+# Events
+reclaim events list --start 2026-02-01 --end 2026-02-28
+reclaim events create --calendar-id 829105 --title "Team sync" \
+  --start 2026-02-21T18:30:00Z --end 2026-02-21T19:00:00Z
 ```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `reclaim list` | List tasks (filter: `open`, `completed`, `IN_PROGRESS`, etc.) |
+| `reclaim get <ID>` | Get a task by ID |
+| `reclaim create` | Create a new task |
+| `reclaim patch <ID>` | Partially update a task |
+| `reclaim put <ID>` | Fully replace a task |
+| `reclaim delete <ID>` | Delete a task |
+| `reclaim dashboard` | Interactive TUI |
+| `reclaim events list` | List calendar events |
+| `reclaim events get` | Get an event |
+| `reclaim events create` | Create an event |
+| `reclaim events update` | Update an event |
+| `reclaim events delete` | Delete an event |
 
 ## Interactive dashboard
 
-Open a terminal dashboard for your tasks:
-
 ```bash
-cargo run --bin reclaim -- dashboard
+reclaim dashboard
 ```
 
 Keyboard shortcuts (Vim-friendly):
-- `j` / `k` (or arrow keys): move selection
-- `g` / `G`: jump to first/last task
-- `?`: toggle help panel
-- `r`: refresh tasks from API
-- Quit with `:q`, `Esc`, or `Ctrl+C`
+- `j`/`k` or arrows: move selection
+- `g`/`G`: jump to first/last task
+- `?`: toggle help
+- `r`: refresh
+- `q`, `Esc`, `Ctrl+C`: quit
 
-Use `--format json` when output should be machine-readable:
+## JSON output
+
+Use `--format json` for machine-readable output:
 
 ```bash
-cargo run --bin reclaim -- list --format json
+reclaim list --format json
+reclaim get 123 --format json
 ```
 
-Use `--json` and `--set key=value` on `put`/`patch` for agent-friendly updates:
+## Field updates
+
+Use `--set key=value` for partial updates:
 
 ```bash
-# Partial update (PATCH)
-cargo run --bin reclaim -- patch 123 \
-  --set priority=P4 \
-  --set snoozeUntil=2026-02-25T17:00:00Z \
-  --format json
+reclaim patch 123 --set priority=P4 --set snoozeUntil=2026-02-25T17:00:00Z
+```
 
-# Full replace (PUT) using a JSON object
-cargo run --bin reclaim -- put 123 --json '{"title":"Plan sprint","priority":"P2"}' --format json
+Or `--json` for full objects:
 
-# Create an event
-cargo run --bin reclaim -- events create \
-  --calendar-id 829105 \
-  --title "UCA Standup" \
-  --start 2026-02-19T18:30:00Z \
-  --end 2026-02-19T19:00:00Z \
-  --priority P1 \
-  --format json
-
-# Update an event using field overrides
-cargo run --bin reclaim -- events update \
-  --calendar-id 829105 \
-  --event-id r2d260ojiopn \
-  --set priority=P4 \
-  --set location="Room A" \
-  --format json
-
-# Advanced event action payload
-cargo run --bin reclaim -- events apply \
-  --json '{"actionsTaken":[{"type":"CancelEventAction","policyId":"00000000-0000-0000-0000-000000000000","eventKey":"829105/r2d260ojiopn"}]}' \
-  --format json
+```bash
+reclaim put 123 --json '{"title":"New title","priority":"P2"}'
 ```
 
 ## Man page
 
-Generate `reclaim(1)` from the clap CLI definition:
+Generate the man page:
 
 ```bash
 cargo run --bin reclaim-man
 ```
 
-By default this writes `man/reclaim.1`. To choose a different destination:
-
-```bash
-cargo run --bin reclaim-man -- --output /tmp/reclaim.1
-```
-
-Release archives also include `reclaim.1` next to the binary.
-
-## API notes
-
-This foundation is based on observed usage from:
-https://github.com/johnjhughes/reclaim-mcp-server
-
-In particular:
-- Base URL: `https://api.app.reclaim.ai/api`
-- Task endpoints: `/tasks`, `/tasks/{id}` (`GET`, `PUT`, `PATCH`, `DELETE`)
-- Event endpoints: `/events`, `/events/{calendarId}/{eventId}`
-- Event mutations: `/schedule-actions/apply-actions` (`AddEventAction`, `UpdateEventAction`, `CancelEventAction`)
+This writes to `man/reclaim.1` by default. Release archives include it next to the binary.

--- a/man/reclaim.1
+++ b/man/reclaim.1
@@ -47,6 +47,9 @@ Print version
 reclaim\-list(1)
 List tasks (active by default).
 .TP
+reclaim\-dashboard(1)
+Open an interactive task dashboard (TUI).
+.TP
 reclaim\-get(1)
 Get one task by ID.
 .TP
@@ -70,6 +73,8 @@ Print this message or the help of the given subcommand(s)
 .SH EXTRA
 Examples:
   reclaim list
+  reclaim list \-\-filter open
+  reclaim dashboard
   reclaim list \-\-all \-\-format json
   reclaim get 123
   reclaim patch 123 \-\-set priority=P4 \-\-set snoozeUntil=2026\-02\-25T17:00:00Z

--- a/man/reclaim.1
+++ b/man/reclaim.1
@@ -45,7 +45,7 @@ Print version
 .SH SUBCOMMANDS
 .TP
 reclaim\-list(1)
-List tasks (active by default).
+List tasks.
 .TP
 reclaim\-dashboard(1)
 Open an interactive task dashboard (TUI).
@@ -74,8 +74,9 @@ Print this message or the help of the given subcommand(s)
 Examples:
   reclaim list
   reclaim list \-\-filter open
+  reclaim list \-\-filter IN_PROGRESS
   reclaim dashboard
-  reclaim list \-\-all \-\-format json
+  reclaim list \-\-format json
   reclaim get 123
   reclaim patch 123 \-\-set priority=P4 \-\-set snoozeUntil=2026\-02\-25T17:00:00Z
   reclaim put 123 \-\-set priority=P2 \-\-set due=2026\-02\-28T17:00:00Z

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use clap::{
 const AFTER_HELP: &str = "\
 Examples:
   reclaim list
+  reclaim list --filter open
   reclaim dashboard
   reclaim list --all --format json
   reclaim get 123
@@ -119,6 +120,17 @@ pub struct ListArgs {
         help = "Include all tasks, including archived/cancelled/deleted."
     )]
     pub all: bool,
+
+    #[arg(long, value_enum, help = "Optional completion-status filter.")]
+    pub filter: Option<TaskCompletionFilter>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum TaskCompletionFilter {
+    #[value(alias = "incomplete")]
+    Open,
+    #[value(alias = "complete", alias = "done")]
+    Completed,
 }
 
 #[derive(Debug, Args)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,8 +7,9 @@ const AFTER_HELP: &str = "\
 Examples:
   reclaim list
   reclaim list --filter open
+  reclaim list --filter IN_PROGRESS
   reclaim dashboard
-  reclaim list --all --format json
+  reclaim list --format json
   reclaim get 123
   reclaim patch 123 --set priority=P4 --set snoozeUntil=2026-02-25T17:00:00Z
   reclaim put 123 --set priority=P2 --set due=2026-02-28T17:00:00Z
@@ -82,7 +83,7 @@ pub struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    #[command(about = "List tasks (active by default).", alias = "ls")]
+    #[command(about = "List tasks.", alias = "ls")]
     List(ListArgs),
     #[command(
         about = "Open an interactive task dashboard (TUI).",
@@ -116,21 +117,35 @@ pub enum Command {
 pub struct ListArgs {
     #[arg(
         long,
-        short = 'a',
-        help = "Include all tasks, including archived/cancelled/deleted."
+        value_enum,
+        help = "Optional task status filter (exact status or bucket)."
     )]
-    pub all: bool,
-
-    #[arg(long, value_enum, help = "Optional completion-status filter.")]
-    pub filter: Option<TaskCompletionFilter>,
+    pub filter: Option<TaskStatusFilter>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
-pub enum TaskCompletionFilter {
-    #[value(alias = "incomplete")]
+pub enum TaskStatusFilter {
+    #[value(name = "open", alias = "incomplete")]
     Open,
-    #[value(alias = "complete", alias = "done")]
+    #[value(name = "completed", alias = "done")]
     Completed,
+    #[value(name = "NEW", alias = "new")]
+    New,
+    #[value(name = "SCHEDULED", alias = "scheduled")]
+    Scheduled,
+    #[value(
+        name = "IN_PROGRESS",
+        alias = "in_progress",
+        alias = "in-progress",
+        alias = "inprogress"
+    )]
+    InProgress,
+    #[value(name = "COMPLETE", alias = "complete")]
+    Complete,
+    #[value(name = "CANCELLED", alias = "cancelled")]
+    Cancelled,
+    #[value(name = "ARCHIVED", alias = "archived")]
+    Archived,
 }
 
 #[derive(Debug, Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod reclaim_api;
 use clap::Parser;
 use cli::{
     Cli, Command, EventsApplyArgs, EventsCommand, EventsCreateArgs, EventsDeleteArgs,
-    EventsUpdateArgs, OutputFormat, PatchArgs, PutArgs, TaskCompletionFilter,
+    EventsUpdateArgs, OutputFormat, PatchArgs, PutArgs, TaskStatusFilter,
 };
 use error::CliError;
 use reclaim_api::{
@@ -38,17 +38,12 @@ async fn run() -> Result<(), CliError> {
 
     match command {
         Command::List(args) => {
-            let filter = if args.all {
-                TaskFilter::All
-            } else {
-                TaskFilter::Active
-            };
-            let mut tasks = api.list_tasks(filter).await?;
-            apply_task_completion_filter(&mut tasks, args.filter);
+            let mut tasks = api.list_tasks(TaskFilter::All).await?;
+            apply_task_status_filter(&mut tasks, args.filter);
 
             match format {
                 OutputFormat::Json => print_json(&tasks)?,
-                OutputFormat::Human => print_task_list_human(args.all, args.filter, &tasks),
+                OutputFormat::Human => print_task_list_human(&tasks, args.filter),
             }
         }
         Command::Dashboard(args) => {
@@ -767,69 +762,56 @@ fn print_json<T: serde::Serialize>(value: &T) -> Result<(), CliError> {
     Ok(())
 }
 
-fn apply_task_completion_filter(tasks: &mut Vec<Task>, filter: Option<TaskCompletionFilter>) {
+fn apply_task_status_filter(tasks: &mut Vec<Task>, filter: Option<TaskStatusFilter>) {
     let Some(filter) = filter else {
         return;
     };
 
     tasks.retain(|task| match filter {
-        TaskCompletionFilter::Open => !task_is_completed(task),
-        TaskCompletionFilter::Completed => task_is_completed(task),
+        TaskStatusFilter::Open => status_indicates_open(task.status.as_deref()),
+        TaskStatusFilter::Completed => status_indicates_completed(task.status.as_deref()),
+        TaskStatusFilter::New => status_matches_exact(task.status.as_deref(), "NEW"),
+        TaskStatusFilter::Scheduled => status_matches_exact(task.status.as_deref(), "SCHEDULED"),
+        TaskStatusFilter::InProgress => status_matches_exact(task.status.as_deref(), "IN_PROGRESS"),
+        TaskStatusFilter::Complete => status_matches_exact(task.status.as_deref(), "COMPLETE"),
+        TaskStatusFilter::Cancelled => status_matches_exact(task.status.as_deref(), "CANCELLED"),
+        TaskStatusFilter::Archived => status_matches_exact(task.status.as_deref(), "ARCHIVED"),
     });
 }
 
-fn task_is_completed(task: &Task) -> bool {
-    if status_indicates_completed(task.status.as_deref()) {
-        return true;
-    }
-
-    if task
-        .extra
-        .get("completionStatus")
-        .and_then(Value::as_str)
-        .is_some_and(|status| status_indicates_completed(Some(status)))
-    {
-        return true;
-    }
-
-    task.extra
-        .get("completed")
-        .and_then(Value::as_bool)
-        .or_else(|| task.extra.get("isComplete").and_then(Value::as_bool))
-        .unwrap_or(false)
-}
-
-fn status_indicates_completed(status: Option<&str>) -> bool {
+fn status_matches_exact(status: Option<&str>, expected: &str) -> bool {
     matches!(
         status.map(|status| status.to_ascii_uppercase()),
-        Some(status)
-            if matches!(status.as_str(), "COMPLETED" | "COMPLETE" | "DONE" | "FINISHED")
+        Some(status) if status == expected
     )
 }
 
-fn print_task_list_human(
-    includes_all: bool,
-    completion_filter: Option<TaskCompletionFilter>,
-    tasks: &[Task],
-) {
-    if tasks.is_empty() {
-        let filter_text = completion_filter.map(|filter| match filter {
-            TaskCompletionFilter::Open => "open",
-            TaskCompletionFilter::Completed => "completed",
-        });
+fn status_indicates_open(status: Option<&str>) -> bool {
+    matches!(
+        status.map(|status| status.to_ascii_uppercase()),
+        Some(status) if matches!(status.as_str(), "NEW" | "SCHEDULED" | "IN_PROGRESS")
+    )
+}
 
-        if includes_all {
-            if let Some(filter_text) = filter_text {
-                println!("No tasks found with completion status '{filter_text}'.");
-            } else {
-                println!("No tasks found.");
-            }
+fn status_indicates_completed(status: Option<&str>) -> bool {
+    status_matches_exact(status, "COMPLETE")
+}
+
+fn print_task_list_human(tasks: &[Task], task_filter: Option<TaskStatusFilter>) {
+    if tasks.is_empty() {
+        if let Some(filter_text) = task_filter.map(|filter| match filter {
+            TaskStatusFilter::Open => "open",
+            TaskStatusFilter::Completed => "completed",
+            TaskStatusFilter::New => "NEW",
+            TaskStatusFilter::Scheduled => "SCHEDULED",
+            TaskStatusFilter::InProgress => "IN_PROGRESS",
+            TaskStatusFilter::Complete => "COMPLETE",
+            TaskStatusFilter::Cancelled => "CANCELLED",
+            TaskStatusFilter::Archived => "ARCHIVED",
+        }) {
+            println!("No tasks found with filter '{filter_text}'.");
         } else {
-            if let Some(filter_text) = filter_text {
-                println!("No active tasks found with completion status '{filter_text}'.");
-            } else {
-                println!("No active tasks found.");
-            }
+            println!("No tasks found.");
         }
         return;
     }
@@ -1104,12 +1086,12 @@ mod tests {
     }
 
     #[test]
-    fn apply_task_completion_filter_matches_status_field() {
+    fn apply_task_status_filter_matches_completed_bucket() {
         let mut tasks = vec![
             Task {
                 id: 1,
                 title: "Plan roadmap".to_string(),
-                status: Some("OPEN".to_string()),
+                status: Some("NEW".to_string()),
                 due: None,
                 priority: None,
                 notes: None,
@@ -1119,7 +1101,7 @@ mod tests {
             Task {
                 id: 2,
                 title: "Archive docs".to_string(),
-                status: Some("COMPLETED".to_string()),
+                status: Some("COMPLETE".to_string()),
                 due: None,
                 priority: None,
                 notes: None,
@@ -1128,31 +1110,68 @@ mod tests {
             },
         ];
 
-        apply_task_completion_filter(&mut tasks, Some(TaskCompletionFilter::Completed));
+        apply_task_status_filter(&mut tasks, Some(TaskStatusFilter::Completed));
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].id, 2);
     }
 
     #[test]
-    fn apply_task_completion_filter_matches_completion_status_extra_field() {
-        let mut completed_extra = std::collections::HashMap::new();
-        completed_extra.insert("completionStatus".to_string(), json!("COMPLETED"));
-
+    fn apply_task_status_filter_matches_open_bucket() {
         let mut tasks = vec![
             Task {
-                id: 123,
-                title: "Prepare launch checklist".to_string(),
-                status: Some("OPEN".to_string()),
+                id: 1,
+                title: "Plan".to_string(),
+                status: Some("NEW".to_string()),
                 due: None,
                 priority: None,
                 notes: None,
                 deleted: false,
-                extra: completed_extra,
+                extra: std::collections::HashMap::new(),
             },
             Task {
-                id: 999,
-                title: "Other item".to_string(),
-                status: Some("OPEN".to_string()),
+                id: 2,
+                title: "Schedule".to_string(),
+                status: Some("SCHEDULED".to_string()),
+                due: None,
+                priority: None,
+                notes: None,
+                deleted: false,
+                extra: std::collections::HashMap::new(),
+            },
+            Task {
+                id: 3,
+                title: "Execute".to_string(),
+                status: Some("IN_PROGRESS".to_string()),
+                due: None,
+                priority: None,
+                notes: None,
+                deleted: false,
+                extra: std::collections::HashMap::new(),
+            },
+            Task {
+                id: 4,
+                title: "Done".to_string(),
+                status: Some("COMPLETE".to_string()),
+                due: None,
+                priority: None,
+                notes: None,
+                deleted: false,
+                extra: std::collections::HashMap::new(),
+            },
+            Task {
+                id: 5,
+                title: "Cancelled".to_string(),
+                status: Some("CANCELLED".to_string()),
+                due: None,
+                priority: None,
+                notes: None,
+                deleted: false,
+                extra: std::collections::HashMap::new(),
+            },
+            Task {
+                id: 6,
+                title: "Archived".to_string(),
+                status: Some("ARCHIVED".to_string()),
                 due: None,
                 priority: None,
                 notes: None,
@@ -1161,21 +1180,65 @@ mod tests {
             },
         ];
 
-        apply_task_completion_filter(&mut tasks, Some(TaskCompletionFilter::Completed));
-        assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].id, 123);
+        apply_task_status_filter(&mut tasks, Some(TaskStatusFilter::Open));
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(tasks[0].id, 1);
+        assert_eq!(tasks[1].id, 2);
+        assert_eq!(tasks[2].id, 3);
     }
 
     #[test]
-    fn apply_task_completion_filter_matches_boolean_extra_fields() {
+    fn apply_task_status_filter_matches_exact_status() {
+        let mut tasks = vec![
+            Task {
+                id: 1,
+                title: "Ready".to_string(),
+                status: Some("SCHEDULED".to_string()),
+                due: None,
+                priority: None,
+                notes: None,
+                deleted: false,
+                extra: std::collections::HashMap::new(),
+            },
+            Task {
+                id: 2,
+                title: "Cancelled".to_string(),
+                status: Some("CANCELLED".to_string()),
+                due: None,
+                priority: None,
+                notes: None,
+                deleted: false,
+                extra: std::collections::HashMap::new(),
+            },
+            Task {
+                id: 3,
+                title: "Archived".to_string(),
+                status: Some("ARCHIVED".to_string()),
+                due: None,
+                priority: None,
+                notes: None,
+                deleted: false,
+                extra: std::collections::HashMap::new(),
+            },
+        ];
+
+        apply_task_status_filter(&mut tasks, Some(TaskStatusFilter::Cancelled));
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, 2);
+    }
+
+    #[test]
+    fn apply_task_status_filter_ignores_extra_completion_fields() {
         let mut completed_extra = std::collections::HashMap::new();
+        completed_extra.insert("completionStatus".to_string(), json!("COMPLETE"));
         completed_extra.insert("completed".to_string(), json!(true));
+        completed_extra.insert("isComplete".to_string(), json!(true));
 
         let mut tasks = vec![
             Task {
                 id: 123,
                 title: "Plan".to_string(),
-                status: Some("OPEN".to_string()),
+                status: Some("NEW".to_string()),
                 due: None,
                 priority: None,
                 notes: None,
@@ -1185,7 +1248,7 @@ mod tests {
             Task {
                 id: 456,
                 title: "Build".to_string(),
-                status: Some("OPEN".to_string()),
+                status: Some("SCHEDULED".to_string()),
                 due: None,
                 priority: None,
                 notes: None,
@@ -1194,8 +1257,7 @@ mod tests {
             },
         ];
 
-        apply_task_completion_filter(&mut tasks, Some(TaskCompletionFilter::Completed));
-        assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].id, 123);
+        apply_task_status_filter(&mut tasks, Some(TaskStatusFilter::Completed));
+        assert_eq!(tasks.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary
- Remove "Foundational Rust CLI" fluff
- Simplify commands to use `reclaim` instead of `cargo run --bin reclaim --`
- Add commands table for quick reference
- Remove merge conflict markers and verbose examples